### PR TITLE
Modify copy-lib.js to create dest path if necessary

### DIFF
--- a/tools/copy-lib.js
+++ b/tools/copy-lib.js
@@ -1,5 +1,5 @@
-import { copyFileSync } from "node:fs";
-import { basename, resolve } from "node:path";
+import { mkdirSync, copyFileSync } from "node:fs";
+import { dirname, basename, resolve } from "node:path";
 
 // copies genart API core and platform adapter into the CWD
 const adapter = process.argv[2] || "urlparams";
@@ -8,5 +8,7 @@ for (const src of [
 	"../../packages/core/genart.js",
 	`../../packages/adapter-${adapter}/adapter-${adapter}.js`,
 ]) {
-	copyFileSync(resolve(src), resolve("public/lib/" + basename(src)));
+	const dest = resolve("public/lib/" + basename(src));
+	mkdirSync(dirname(dest), { recursive: true });
+	copyFileSync(resolve(src), dest);
 }


### PR DESCRIPTION
- Ensures the destination directory is created recursively before copying files.