### PR TITLE
fix(project-template): fix typo in package dependencies

### DIFF
--- a/project-template/package.json
+++ b/project-template/package.json
@@ -19,6 +19,6 @@
 	},
 	"dependencies": {
 		"@genart-api/core": "^0.28.0",
-		"@genart-api/adpater-urlparams": "^0.28.0"
+		"@genart-api/adapter-urlparams": "^0.28.0"
 	}
 }


### PR DESCRIPTION
Hi @postspectacular, this fixes a typo in a list of dependencies.